### PR TITLE
修改pip安装依赖

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -39,7 +39,7 @@ if [ ${OS} == Ubuntu ] || [ ${OS} == Debian ];then
 	apt-get install wget curl socat git unzip python python-dev openssl libssl-dev ca-certificates supervisor -y
 	wget -O - "https://bootstrap.pypa.io/get-pip.py" | python
 	pip install --upgrade pip
-	pip install flask requests urllib3 Flask-BasicAuth supervisor Jinja2 requests six wheel
+	pip install flask requests urllib3 Flask-BasicAuth Jinja2 requests six wheel
 	pip install pyOpenSSL
 fi
 
@@ -65,8 +65,7 @@ curl -L -s https://install.direct/go.sh | bash
 
 #Install V2ray.Fun
 cd /usr/local/
-git clone https://github.com/mingxin0130/V2ray.Fun
-
+git clone https://github.com/FunctionClub/V2ray.Fun
 
 #Generate Default Configurations
 cd /usr/local/V2ray.Fun/ && python init.py


### PR DESCRIPTION
1.在debian环境中，已用包管理器安装supervisor，无需使用pip安装
2.修改安装脚本地址